### PR TITLE
Improved teleport

### DIFF
--- a/project_snek/scenes/main_scene.tscn
+++ b/project_snek/scenes/main_scene.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://bsp4xibu18oo0"]
+[gd_scene load_steps=7 format=3 uid="uid://bsp4xibu18oo0"]
 
 [ext_resource type="Texture2D" uid="uid://c645jjh1nxsa6" path="res://static sprites/tmp_bg.png" id="1_6rov2"]
 [ext_resource type="PackedScene" uid="uid://dddj0jy148j2l" path="res://scenes/player.tscn" id="1_bisvo"]
@@ -9,21 +9,21 @@
 distance = -742.965
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_6om2b"]
-size = Vector2(1088, 20)
-
-[sub_resource type="CanvasItemMaterial" id="CanvasItemMaterial_hykep"]
-blend_mode = 1
+size = Vector2(3949, 37)
 
 [node name="main" type="Node2D"]
 
 [node name="Screenshot-2024-10-30-18-40-38" type="Sprite2D" parent="."]
-position = Vector2(520, -16.0001)
-scale = Vector2(35.42, 22.86)
+position = Vector2(516, -51)
+rotation = 0.0174533
+scale = Vector2(35.61, 22.72)
 texture = ExtResource("1_6rov2")
 
 [node name="enemy_root-node" parent="." instance=ExtResource("3_hlimb")]
 position = Vector2(7.62939e-06, 1072)
 rotation = 0.0174401
+collision_layer = 3
+collision_mask = 5
 
 [node name="CharacterBody2D" parent="." instance=ExtResource("1_bisvo")]
 
@@ -37,33 +37,28 @@ shape = SubResource("WorldBoundaryShape2D_vi77q")
 
 [node name="temp_test_platform" type="StaticBody2D" parent="."]
 position = Vector2(1985, 1138)
+collision_layer = 4
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="temp_test_platform"]
+position = Vector2(-1434, -68)
 shape = SubResource("RectangleShape2D_6om2b")
 
 [node name="Sprite2D" type="Sprite2D" parent="temp_test_platform/CollisionShape2D"]
-scale = Vector2(10.87, 0.2)
+position = Vector2(1, -7.25002)
+scale = Vector2(39.62, 0.335001)
 texture = ExtResource("4_e3msa")
 
 [node name="temp_test_platform2" type="StaticBody2D" parent="."]
 position = Vector2(2310, 787)
 rotation = 1.5708
+collision_layer = 4
+collision_mask = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="temp_test_platform2"]
 shape = SubResource("RectangleShape2D_6om2b")
 
 [node name="Sprite2D" type="Sprite2D" parent="temp_test_platform2/CollisionShape2D"]
-scale = Vector2(10.87, 0.2)
-texture = ExtResource("4_e3msa")
-
-[node name="temp_test_platform3" type="StaticBody2D" parent="."]
-position = Vector2(14, 178)
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="temp_test_platform3"]
-shape = SubResource("RectangleShape2D_6om2b")
-
-[node name="Sprite2D" type="Sprite2D" parent="temp_test_platform3/CollisionShape2D"]
-material = SubResource("CanvasItemMaterial_hykep")
 scale = Vector2(10.87, 0.2)
 texture = ExtResource("4_e3msa")
 

--- a/project_snek/scenes/player.tscn
+++ b/project_snek/scenes/player.tscn
@@ -39,21 +39,17 @@ func _physics_process(delta):
 ### teleport
 
 	if Input.is_action_just_pressed(\"mouse_RC\"):
-		var dir = 0
-		
-		
+		var dir = 0 # if you walk right or left
 		if(velocity.x>0):
-			dir=1
+			dir=1  #right
 		elif(velocity.x<0):
-			dir=-1
+			dir=-1 #left
 		else:
 			return
 		print(\"move\")
-			
-		
 		$Sprite2D.visible=false
-		$Sprite2D2.visible=true
-		teleport_to(position+Vector2(500*dir,0))
+		$Sprite2D2.visible=true  # makes player invisible inbetween teleport
+		teleport_to(position+Vector2(500*dir,0)) # 500 = teleport lenght
 		await get_tree().create_timer(0.25).timeout  # 0.25 seconds delay (250ms)s)
 		
 		$Sprite2D.visible=true
@@ -112,20 +108,26 @@ func take_damage(damage):
 
 ### Teleport
 
-func teleport_to(new_position:Vector2):
-	var raycast = $RayCast2D
-	raycast.global_position= global_position
-	raycast.enabled=true
-	
-	if raycast.is_colliding():
-		print(\"Blocked\")
-		raycast.enabled=false
+
+func teleport_to(new_position: Vector2):
+	# Check if moving to the new position will collide with any object
+	collision_mask = 4 # Makes the player able to teleport trough enemies
+	var collision = test_move(global_transform, new_position - global_position)
+	 
+	if collision:  # collision with mask 3
+		print(\"Blocked, cannot teleport to:\", new_position)
 	else:
-		position= new_position
-		await get_tree().create_timer(0.1).timeout  # 0.25 seconds delay (250ms)s)aaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		position= new_position
+		print(\"Teleporting to:\", new_position)
+		$Sprite2D.visible = false
+		$Sprite2D2.visible = true
+		await get_tree().create_timer(0.25).timeout  # 250ms delay  #just fancy trying to make the teleport look better/otional
+		global_position = new_position
+		$Sprite2D.visible = true
+		$Sprite2D2.visible = false
+	collision_mask = 6 # Make the player able to collide with enemy after teleport
 	
-	raycast.enabled=false
+	
+
 	
 ###
 
@@ -213,6 +215,7 @@ states/Walk_down/position = Vector2(406, 82)
 graph_offset = Vector2(-156, -5)
 
 [node name="CharacterBody2D" type="CharacterBody2D"]
+collision_mask = 6
 script = SubResource("GDScript_isu8i")
 max_walljump = -2
 
@@ -259,9 +262,6 @@ position = Vector2(0.499959, 0.5)
 scale = Vector2(1.19948, 1.19907)
 texture = ExtResource("4_tuknr")
 script = ExtResource("5_nksik")
-
-[node name="RayCast2D" type="RayCast2D" parent="."]
-enabled = false
 
 [node name="Sprite2D2" type="Sprite2D" parent="."]
 visible = false


### PR DESCRIPTION
added mask and layer collide which made it possible to teleport trough enemy but not walls. This is tough only teleport x axis but should not be a problem adding y axis also. changed the floor so its not tilted. Maybe fix so insteed of error when its a "block" its teleport to the closets place like you teleport right before the wall.